### PR TITLE
Improve Appwrite Messaging with Socketlabs Adapter

### DIFF
--- a/src/Utopia/Messaging/Socketlabs.php
+++ b/src/Utopia/Messaging/Socketlabs.php
@@ -1,0 +1,72 @@
+<?php
+namespace Socketlabs\Appwrite\Adapter;
+
+use Appwrite\Messaging\Adapter;
+use Socketlabs\Messaging\Client;
+use Socketlabs\Messaging\Email; 
+
+class SocketlabsAdapter extends Adapter
+{
+    private Client $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function send(array $message): bool
+    {
+        $email = new Email();
+        $email
+            ->setFrom($message['from'])
+            ->setTo($message['to'])
+            ->setSubject($message['subject'])
+            ->setBody($message['body']);
+
+        $response = $this->client->send($email);
+
+        return $response->isSuccess();
+    }
+
+    public function trackOpen(string $messageId): bool
+    {
+        $response = $this->client->trackOpen($messageId);
+
+        return $response->isSuccess();
+    }
+
+    public function trackClick(string $messageId, string $link): bool
+    {
+        $response = $this->client->trackClick($messageId, $link);
+
+        return $response->isSuccess();
+    }
+
+    public function getTemplate(string $templateId): array
+    {
+        $response = $this->client->getTemplate($templateId);
+
+        return $response->getData();
+    }
+
+    public function createTemplate(array $template): string
+    {
+        $response = $this->client->createTemplate($template);
+
+        return $response->getData()['id'];
+    }
+
+    public function updateTemplate(string $templateId, array $template): bool
+    {
+        $response = $this->client->updateTemplate($templateId, $template);
+
+        return $response->isSuccess();
+    }
+
+    public function deleteTemplate(string $templateId): bool
+    {
+        $response = $this->client->deleteTemplate($templateId);
+
+        return $response->isSuccess();
+    }
+}


### PR DESCRIPTION
Description The Appwrite Messaging adapter for Socketlabs can be improved in a number of ways, including:

Add support for more features: The Socketlabs adapter currently only supports sending emails. It could be improved by adding support for other features, such as tracking email opens and clicks, and managing email templates.
Make the adapter more efficient: The Socketlabs adapter could be made more efficient by optimizing the code to send emails more quickly and efficiently.
Make the adapter more user-friendly: The Socketlabs adapter could be made more user-friendly by providing better documentation and tutorials.
The Following below are some specific suggestions for improving the Socketlabs adapter:

Add support for tracking email opens and clicks: This would allow Appwrite developers to track the performance of their email campaigns and see how many people are opening and clicking on their emails.

Add support for managing email templates: This would allow Appwrite developers to create and manage email templates that they can reuse for different types of emails, such as welcome emails, confirmation emails, and newsletter emails.

Optimize the code to send emails more quickly and efficiently: This would improve the performance of the Socketlabs adapter and make it more suitable for sending large numbers of emails.

Provide better documentation and tutorials: This would make it easier for Appwrite developers to learn how to use the Socketlabs adapter and start sending emails.

In addition to these specific suggestions, the Socketlabs adapter could also be improved by making it more customizable and extensible. This would allow Appwrite developers to add their own features and functionality to the adapter.

Overall, the Socketlabs adapter for Appwrite Messaging is a good start, but there is still room for improvement. By adding support for more features, making the adapter more efficient and user-friendly, and making it more customizable and extensible, the Socketlabs adapter could become a powerful tool for Appwrite developers to send emails and other types of messages.

Value Added suggestions for improving the Socketlabs adapter:

Support multiple email providers: The Socketlabs adapter is currently only integrated with Socketlabs. It could be improved by adding support for other email providers, such as SendGrid, Mailchimp, and Amazon SES.

Provide a unified API: The Socketlabs adapter currently exposes a different API for each of the features it supports. It could be improved by providing a unified API that makes it easier for Appwrite developers to use all of the features of the adapter.

Add support for batch processing: The Socketlabs adapter currently only supports sending emails one at a time. It could be improved by adding support for batch processing, which would allow Appwrite developers to send multiple emails at once.

Add support for retries: The Socketlabs adapter currently does not retry sending emails if they fail. It could be improved by adding support for retries, which would ensure that all emails are eventually delivered.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
